### PR TITLE
Bug 788531 - Revise default delay for endurance test to make scenarios more realistic

### DIFF
--- a/mozmill_automation/testrun.py
+++ b/mozmill_automation/testrun.py
@@ -302,7 +302,7 @@ class EnduranceTestRun(TestRun):
         endurance = optparse.OptionGroup(parser, "Endurance options")
         endurance.add_option("--delay",
                              dest="delay",
-                             default=0.1,
+                             default=5,
                              type="float",
                              metavar="DELAY",
                              help="seconds to wait before each iteration "


### PR DESCRIPTION
This has already been fixed in mozmill-automation, so carrying this across for the new package. This is dependant on pull #29
