### PR TITLE
Don't enforce hard dependencies to dependent packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,12 @@ mozmill-automation
 ==================
 
 Automation scripts for Mozmill test execution
+
+
+Installation
+------------
+
+The scripts can be installed by running the following commands:
+
+    python setup.py develop
+    pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+mercurial==2.1
+mozinstall==1.5
+mozmill==2.0rc3

--- a/setup.py
+++ b/setup.py
@@ -14,10 +14,6 @@ except IOError:
 NAME = 'mozmill-automation'
 VERSION = '0.1'
 
-deps = ['mercurial==2.1',
-        'mozinstall==1.5',
-        'mozmill==2.0rc2']
-
 setup(name=NAME,
       version=VERSION,
       description="Automation scripts for Mozmill test execution",
@@ -39,7 +35,6 @@ setup(name=NAME,
       packages=find_packages(exclude=['legacy']),
       include_package_data=True,
       zip_safe=False,
-      install_requires=deps,
       entry_points="""
       # -*- Entry points: -*-
       [console_scripts]


### PR DESCRIPTION
As described in the following article, it is better to not have hard dependencies but leave it to the user which packages are installed. Dependencies should be part of the requirements.txt file.
