### PR TITLE
URL sent using --report='http://mozmill-crowd.blargon7.com/db' doesnt handle link properly in report generation(#58)

### DIFF
--- a/mozmill_automation/testrun.py
+++ b/mozmill_automation/testrun.py
@@ -195,7 +195,7 @@ class TestRun(object):
         handlers = [logger]
         
         if self.options.report_url[-1] != '/':
-            self.options.report_url+='/'
+            self.options.report_url += '/'
         
         if self.options.report_url:
             self.report = reports.DashboardReport(self.options.report_url, self)

--- a/mozmill_automation/testrun.py
+++ b/mozmill_automation/testrun.py
@@ -193,6 +193,10 @@ class TestRun(object):
                                                file_level=self.debug and 'DEBUG' or 'INFO',
                                                debug=self.debug)
         handlers = [logger]
+        
+        if self.options.report_url[-1]!='/':
+			self.options.report_url+='/'
+        
         if self.options.report_url:
             self.report = reports.DashboardReport(self.options.report_url, self)
             handlers.append(self.report)

--- a/mozmill_automation/testrun.py
+++ b/mozmill_automation/testrun.py
@@ -194,8 +194,8 @@ class TestRun(object):
                                                debug=self.debug)
         handlers = [logger]
         
-        if self.options.report_url[-1]!='/':
-			self.options.report_url+='/'
+        if self.options.report_url[-1] != '/':
+            self.options.report_url+='/'
         
         if self.options.report_url:
             self.report = reports.DashboardReport(self.options.report_url, self)


### PR DESCRIPTION
Added the code to handle the link, appending '/' in the end of the report link.
