### PR TITLE
Update build versions in testrun_compat_addons.json.example in hotfix-1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ which should usually be hosted at http://addons.mozilla.org.
 
 The `testrun_compat_addons` script is a special testrun to execute add-on
 compatibility tests for Firefox, which ensures that major add-ons are still
-working as expected for a new major release of Firefox.
+working as expected for a new major release of Firefox. An example config
+file is provided in the repo. One or more builds can be defined in the file.
 
 ## Endurance
 The `testrun_endurance` script executes the endurance tests for Firefox,

--- a/mozmill_automation/configs/testrun_compat_addons.json.example
+++ b/mozmill_automation/configs/testrun_compat_addons.json.example
@@ -1,7 +1,7 @@
 {
   "settings": {
     "addons_per_run": 5,
-    "builds": ["10.0b6", "10.0.2", "10.0.3esr"],
+    "builds": ["24.0esr"],
     "staging_path": "_staging",
     "testrun_options": [
       "--report=http://mozmill-addons.blargon7.com/db/",


### PR DESCRIPTION
Pull request for review.

I did a testrun_compat_addons with the new config and it appears to be pulling the 24.0esr build correctly.

I also updated the ReadMe as discussed in the issue.

Adding @whimboo and @davehunt for visibility.
