### PR TITLE
Remove Google Toolbar xpi from compat_addons example in hotfix-1.5

### DIFF
--- a/mozmill_automation/configs/testrun_compat_addons.json.example
+++ b/mozmill_automation/configs/testrun_compat_addons.json.example
@@ -20,9 +20,6 @@
       "amo_id": 13661,
       "platforms": ["winnt", "darwin", "linux"]
     }, {
-      "name": "Google Toolbar",
-      "url": "https://dl-ssl.google.com/firefox/google-toolbar-beta-win-h_asknot-d_asknot.xpi"
-    }, {
       "name": "Firebug",
       "url": "http://addons.mozilla.org/firefox/downloads/latest/1843/addon-1843-latest.xpi",
       "amo_id": 1843


### PR DESCRIPTION
Pull request for review.

This change removes the discontinued Google Toolbar xpi, as discussed in issue https://github.com/mozilla/mozmill-automation/issues/82.

I did a testrun_compat_addons with mozmill-env 1.5.22.1 using mozmill 1.5.22 with the new config and the failure no longer occurs, and the empty Google staging dirs are also no longer generated.

Tested in
Windows XPSP3

Adding @whimboo and @davehunt for visibility.
