### PR TITLE
[1.5] Update automation script to also handle the new application-based structure

### DIFF
--- a/mozmill_automation/errors.py
+++ b/mozmill_automation/errors.py
@@ -14,10 +14,10 @@ class NotSupportedTestrunException(Exception):
     """Class for a testrun not being supported exception."""
 
     def __init__(self, testrun):
-        Exception.__init__(self, "Testrun not supported: %s" % testrun.__class__.__name__)
+        Exception.__init__(self, 'Testrun not supported: %s' % testrun.__class__.__name__)
 
 class TestFailedException(Exception):
     """Class for tests failing during a testrun exception"""
 
     def __init__(self):
-        Exception.__init__(self, "Some tests have been failed.")
+        Exception.__init__(self, 'Some tests have been failed.')


### PR DESCRIPTION
Added a check to see if the current path doesn't exist, to update it by including the application name.

Application is already by default firefox, if none provided. I did not add metrofirefox here since we will not use 1.5 for metro.

Performed testruns with both current mozmill-tests and with the new structure patch applied. Both work, please see reports:
http://pastebin.mozilla.org/3318426
