### PR TITLE
[1.5] Remove metrofirefox from supported apps (#89)

### DIFF
--- a/mozmill_automation/testrun.py
+++ b/mozmill_automation/testrun.py
@@ -82,7 +82,7 @@ class TestRun(object):
                                                 help="Add-ons to install",
                                                ),
                       ("--application",): dict(dest="application",
-                                               choices=["firefox", "metrofirefox", "thunderbird"],
+                                               choices=["firefox", "thunderbird"],
                                                metavar="APP",
                                                default="firefox",
                                                help="Application Name, i.e. firefox, thunderbird"),


### PR DESCRIPTION
Removed metrofirefox support, we can't run this under 1.5

@whimboo please review this
