### PR TITLE
Updated mozmill version dependency to 2.1-dev for master (#94)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ VERSION = '2.1-dev'
 deps = ['mercurial == 2.6.2',
         'mozdownload==1.9',
         'mozinstall == 1.7',
-        'mozmill == 2.0rc5',
+        'mozmill == 2.1-dev',
         ]
 
 setup(name=NAME,


### PR DESCRIPTION
We should use master/mozmill-automation with master/mozmill so I updated the mozmill-version dependency.

@whimboo please review this
