### PR TITLE
Remove trailing slash from url to not delete CWD when attempting repository.remove() #99

### DIFF
--- a/mozmill_automation/repository.py
+++ b/mozmill_automation/repository.py
@@ -6,6 +6,7 @@ import mozinfo
 import os
 import re
 import shutil
+import urlparse
 
 import process
 
@@ -28,7 +29,8 @@ class MercurialRepository(object):
         else:
             # If no local path has been specified we generate it from the
             # current working directory and the name of the remote repository
-            self.path = os.path.join(os.getcwd(), os.path.basename(url))
+            name = urlparse.urlparse(self.url).path.rstrip('/').rsplit('/')[-1]
+            self.path = os.path.join(os.getcwd(), name)
 
     def _exec(self, arguments, is_cloning=False):
         """Execute the given hg command and return the output"""


### PR DESCRIPTION
This fixes the problem of removing the **current working directory** when the testrun fails before the `mozmill-tests` repository has been properly cloned.

See issue #99

The issue here is that if we have a trailing slash in the url, instead of trying to delete _cwd + repository_name_ are are issuing the command to delete the _cwd_

I'm thinking we should revisit this and not even **try** to delete the repository if it wasn't successfully cloned.  

@davehunt & @whimboo please have a look at this
I am fine with just this quick fix for now, but if you feel we should make more significant changes as mentioned in the previous paragraph, please let me know.

Thanks
