### PR TITLE
Port testrun compat_addons from hotfix-1.5 to master (#69)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ which should usually be hosted at http://addons.mozilla.org.
 
 The `testrun_compat_addons` script is a special testrun to execute add-on
 compatibility tests for Firefox, which ensures that major add-ons are still
-working as expected for a new major release of Firefox.
+working as expected for a new major release of Firefox. An example config
+file is provided in the repo. One or more builds can be defined in the file.
 
 ## Endurance
 The `testrun_endurance` script executes the endurance tests for Firefox,

--- a/mozmill_automation/__init__.py
+++ b/mozmill_automation/__init__.py
@@ -2,5 +2,5 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
-
 from testrun import *
+from compat_by_default import *

--- a/mozmill_automation/compat_by_default.py
+++ b/mozmill_automation/compat_by_default.py
@@ -1,0 +1,199 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+import copy
+import shutil
+import sys
+import tempfile
+import optparse
+from urlparse import urlsplit
+
+from mozdownload import ReleaseScraper
+
+import application
+import errors
+import mozinstall
+from json_file import JSONFile
+from testrun import *
+
+
+class CompatibleByDefault:
+    """Class to run the add-ons compatible by default tests."""
+
+    def __init__(self, config_file, repository=None):
+        self._config = JSONFile(config_file).read()
+        self._repository = repository
+
+        self.staging_path = os.path.abspath(self._config['settings']['staging_path'])
+
+
+    @property
+    def platform(self):
+        if sys.platform in ['darwin']:
+            return sys.platform
+        elif sys.platform in ['win32', 'cygwin']:
+            return 'winnt'
+        elif sys.platform in ['linux2', 'linux3']:
+            return 'linux'
+
+
+    def _run_tests(self, build, default_testrun_options):
+        """Execute the tests for the given build"""
+
+        cur_index = 0
+        firstrun = True
+        addons = self._config['addons']
+
+        # Iterate in chunks over all extended add-ons
+        while cur_index < len(addons['extended']):
+            try:
+                addon_set = copy.copy(addons['default'])
+                if firstrun:
+                    # For the first run we do only install the default add-ons
+                    firstrun = False
+                else:
+                    # Otherwise retrieve the next number of extended add-ons
+                    max_index = cur_index + self._config['settings']['addons_per_run']
+                    addons_extended = addons['extended'][cur_index:max_index]
+                    addon_set.extend(addons_extended)
+                    cur_index += len(addons_extended)
+
+                # Build testrun options for add-ons to test
+                addon_options = [ ]
+                tags = [ ]
+
+                for addon in addon_set:
+                    addon_options.append('--addons=%s' % addon['local_url'])
+                    tags.append('--tag=%s' % addon['name'])
+
+                # Install the specified build so we don't have to do it for
+                # each individual testrun.
+                install_path = tempfile.mkdtemp('.binary')
+                folder = mozinstall.install(build, install_path)
+                binary = mozinstall.get_binary(folder, 'firefox')
+
+                # Setup all necessary testrun options to test the build
+                testrun_options = copy.copy(default_testrun_options)
+                testrun_options.append(binary)
+                testrun_options.extend(addon_options)
+                testrun_options.extend(tags)
+
+                # Setup profile for testing
+                profile_path = tempfile.mkdtemp(suffix='profile')
+                testrun_options.append('--profile=' + profile_path)
+
+                # Execute testruns
+                self.execute_testrun(EnduranceTestRun, testrun_options)
+                self.execute_testrun(UpdateTestRun, testrun_options, ['--no-fallback'])
+                self.execute_testrun(EnduranceTestRun, testrun_options)
+
+                # Ensure to remove the temporarily created profile
+                shutil.rmtree(profile_path, True)
+
+            finally:
+                mozinstall.uninstall(folder)
+
+
+    def download_addon(self, url, target_path):
+        """Download an add-on given by the URL."""
+        try:
+            filename = urlsplit(url).path.rsplit('/')[-1]
+            target_path = os.path.join(target_path, filename)
+            if not os.path.exists(target_path):
+                urllib.urlretrieve(url, target_path)
+
+            return target_path
+        except Exception, e:
+            raise errors.NotFoundException("Add-on cannot be downloaded: %s" % str(e),
+                                           url)
+
+
+    def execute_testrun(self, testrun, options, extra_options=None):
+        """Execute the specified testrun with the given options."""
+
+        testrun_options = copy.copy(options)
+        if isinstance(extra_options, list):
+            testrun_options.extend(extra_options)
+
+        try:
+            testrun(testrun_options).run()
+        except Exception, e:
+            self._exceptions.append(e)
+
+
+    def run(self):
+        """Execute the compatible by default testrun."""
+
+        # Stage builds and add-ons required by the testrun
+        self.stage_addons()
+        self.stage_builds()
+
+        # Setup the default options for the testruns from the config
+        config_options = self._config['settings']['testrun_options']
+        default_testrun_options = [option for option in config_options]
+
+        self._exceptions = [ ]
+        for build in self._local_builds:
+            self._run_tests(build, default_testrun_options)
+
+        # Always clean-up the staging folder
+        print "Clean-up staging folder."
+        shutil.rmtree(self.staging_path, True)
+
+        # If test failures have been reported simply throw the last raised
+        # exception. It also ensures a correct exit code.
+        if self._exceptions:
+            raise self._exceptions[-1]
+
+
+    def stage_addons(self):
+        """Stage add-ons under test as specified in the config file."""
+
+        if not os.path.exists(self.staging_path):
+            os.mkdir(self.staging_path)
+
+        for addon_type in ['default', 'extended']:
+            removable_addons = [ ]
+
+            # Iterate over each add-on and download if it matches the platform.
+            for addon in self._config['addons'][addon_type]:
+                if 'platforms' in addon and not self.platform in addon['platforms']:
+                    print 'Skip: Add-on "%s" not available on %s' % (addon['name'],
+                                                                     self.platform)
+                    removable_addons.append(addon)
+                    continue
+
+                print 'Staging add-on "%s" (%s)' % (addon['name'], addon['url'])
+                addon['local_url'] = self.download_addon(addon['url'],
+                                                         self.staging_path)
+
+            # Remove not testable add-ons
+            for addon in removable_addons:
+                self._config['addons'][addon_type].remove(addon)
+
+
+    def stage_builds(self):
+        self._local_builds = [ ]
+
+        for build in self._config['settings']['builds']:
+            scraper = ReleaseScraper(directory=self.staging_path,
+                                     version=build)
+            scraper.download()
+            self._local_builds.append(scraper.target)
+
+
+def compat_addons_cli():
+    usage = "usage: %prog [options] config-file"
+    parser = optparse.OptionParser(usage=usage)
+    parser.add_option('--repository',
+                      dest='repository',
+                      help='URL of a remote or local mozmill-test repository.')
+    (options, args) = parser.parse_args()
+
+    if not len(args) is 1:
+        parser.error('A configuration file has to be specified.')
+
+    cbd = CompatibleByDefault(args[0], options.repository)
+    cbd.run()

--- a/mozmill_automation/configs/testrun_compat_addons.json.example
+++ b/mozmill_automation/configs/testrun_compat_addons.json.example
@@ -1,0 +1,44 @@
+{
+  "settings": {
+    "addons_per_run": 5,
+    "builds": ["24.0esr"],
+    "staging_path": "_staging",
+    "testrun_options": [
+      "--report=http://mozmill-addons.blargon7.com/db/",
+      "--tag=addon_compat_fx11.0"
+    ]
+  },
+  "addons": {
+    "default": [{
+      "name": "Adblock Plus",
+      "url": "http://addons.mozilla.org/firefox/downloads/latest/1865/addon-1865-latest.xpi",
+      "amo_id": 1865
+    }],
+    "extended": [{
+      "name": "Test Pilot",
+      "url": "http://stage.mozilla.org/pub/mozilla.org/addons/13661/test_pilot-1.2-fx-windows.xpi",
+      "amo_id": 13661,
+      "platforms": ["winnt", "darwin", "linux"]
+    }, {
+      "name": "Firebug",
+      "url": "http://addons.mozilla.org/firefox/downloads/latest/1843/addon-1843-latest.xpi",
+      "amo_id": 1843
+    }, {
+      "name": "Greasemonkey",
+      "url": "http://addons.mozilla.org/firefox/downloads/latest/748/addon-748-latest.xpi",
+      "amo_id": 748
+    }, {
+      "name": "Personas Plus",
+      "url": "http://addons.mozilla.org/firefox/downloads/latest/10900/addon-10900-latest.xpi",
+      "amo_id": 10900
+    }, {
+      "name": "Download Statusbar",
+      "url": "http://addons.mozilla.org/firefox/downloads/latest/26/addon-26-latest.xpi",
+      "amo_id": 26
+    }, {
+      "name": "DownThemAll!",
+      "url": "http://addons.mozilla.org/firefox/downloads/latest/201/addon-201-latest.xpi",
+      "amo_id": 201
+    }]
+  }
+}

--- a/mozmill_automation/json_file.py
+++ b/mozmill_automation/json_file.py
@@ -1,0 +1,39 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+import json
+import os
+
+import errors
+
+
+class JSONFile:
+    """Class to handle reading and writing of JSON files."""
+
+    def __init__(self, filename):
+        self.filename = os.path.abspath(filename)
+
+
+    def read(self):
+        if not os.path.isfile(self.filename):
+            raise errors.NotFoundException('Specified file cannot be found.',
+                                           self.filename)
+
+        try:
+            f = open(self.filename, 'r')
+            return json.loads(f.read())
+        finally:
+            f.close()
+
+
+    def write(self, data):
+        try:
+            folder = os.path.dirname(self.filename)
+            if not os.path.exists(folder):
+                os.makedirs(folder)
+            f = open(self.filename, 'w')
+            f.write(json.dumps(data))
+        finally:
+            f.close()

--- a/setup.py
+++ b/setup.py
@@ -45,10 +45,11 @@ setup(name=NAME,
       # -*- Entry points: -*-
       [console_scripts]
       testrun_addons = mozmill_automation:addons_cli
+      testrun_compat_addons = mozmill_automation:compat_addons_cli
       testrun_endurance = mozmill_automation:endurance_cli
       testrun_functional = mozmill_automation:functional_cli
       testrun_l10n = mozmill_automation:l10n_cli
       testrun_remote = mozmill_automation:remote_cli
       testrun_update = mozmill_automation:update_cli
-      """,
+      """
       )


### PR DESCRIPTION
Pull request for review.

I did a testrun_compat_addons with the 24.0esr build and the default json.example config, and it appears to be running correctly.

Tested in:
Windows XP32 SP3
mozmill-env 1.5.24.1 latest + mozmill master latest + this branch

Run result:
http://mozmill-addons.blargon7.com/db/456bebe92845279408c15c03e874eb81

Adding @whimboo and @davehunt for visibility.
