### PR TITLE
Don't treat the 'filename' if we don't have one when sending reports #130

### DIFF
--- a/mozmill_automation/reports.py
+++ b/mozmill_automation/reports.py
@@ -130,27 +130,29 @@ class JUnitReport(Report):
         testsuite_element.setAttribute('time', str((time_end - time_start).seconds))
 
         for result in report['results']:
-            filename = result['filename']
-            root_path = '/'.join(['tests', report_type.split('firefox-')[1]])
+            class_name = 'undefined'
+            if 'filename' in result:
+                filename = result['filename']
+                root_path = '/'.join(['tests', report_type.split('firefox-')[1]])
 
-            # replace backslashes with forward slashes
-            filename = filename.replace('\\', '/')
+                # replace backslashes with forward slashes
+                filename = filename.replace('\\', '/')
 
-            # strip temporary and common path elements, and strip trailing forward slash
-            class_name = filename.partition(root_path)[2].lstrip('/')
+                # strip temporary and common path elements, and strip trailing forward slash
+                class_name = filename.partition(root_path)[2].lstrip('/')
 
-            # strip the file extension
-            class_name = os.path.splitext(class_name)[0]
+                # strip the file extension
+                class_name = os.path.splitext(class_name)[0]
 
-            # replace periods with underscore to avoid them being interpreted as package seperators
-            class_name = class_name.replace('.', '_')
+                # replace periods with underscore to avoid them being interpreted as package seperators
+                class_name = class_name.replace('.', '_')
 
-            # replace path separators with periods to give implied package hierarchy
-            class_name = class_name.replace('/', '.')
+                # replace path separators with periods to give implied package hierarchy
+                class_name = class_name.replace('/', '.')
 
             testcase_element = doc.createElement('testcase')
             testcase_element.setAttribute('classname', str(class_name))
-            testcase_element.setAttribute('name', str(result['name']).rpartition('::')[2])
+            testcase_element.setAttribute('name', str(result.get('name', 'undefined')).rpartition('::')[2])
 
             time = '0'
             if 'time_start' in result and 'time_end' in result:


### PR DESCRIPTION
This is for issue #130

If the disconnect happens before the frame starts we don't start any test so we won't have a filename for the test we failed in. This will cause an KeyError in get_report method in JUnitReport class.
The easiest way to avoid that would be to ad a check that we have a filename.
