### PR TITLE
Update testrun fails when creating backups of the binary (#136)

### DIFF
--- a/mozmill_automation/testrun.py
+++ b/mozmill_automation/testrun.py
@@ -655,7 +655,7 @@ class UpdateTestRun(TestRun):
             self._backup_folder = os.path.join(self.workspace, 'binary_backup')
 
             print "*** Creating backup of binary: %s" % self._backup_folder
-            mozfile.remove(self._backup_folder, True)
+            mozfile.remove(self._backup_folder)
             shutil.copytree(self._folder, self._backup_folder)
 
     def prepare_channel(self):


### PR DESCRIPTION
This will fix issue #136. @andreeamatei can you please have a look?
