### PR TITLE
Upgrade mozversion for handling new signed builds on OS X (#166)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ deps = ['mercurial == 2.6.2',
         'mozfile == 1.1',
         'mozinstall == 1.9',
         'mozmill == 2.0.6',
-        'mozversion >= 0.4'
+        'mozversion >= 0.7'
         ]
 
 setup(name=NAME,


### PR DESCRIPTION
This PR fixes issue #166 by setting the minimum supported version to 0.7. @andreeamatei can you please have a look at?
