### PR TITLE
Upgrade mozversion for handling new signed builds on OS X (#166)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ deps = ['mercurial == 2.6.2',
         'mozfile >= 1.0',
         'mozinstall >= 1.7',
         'mozmill == 2.1-dev',
-        'mozversion >= 0.4'
+        'mozversion >= 0.7'
         ]
 
 setup(name=NAME,


### PR DESCRIPTION
@andreeamatei this is the fix for the master branch on issue #166, which I missed to upload.
