### PR TITLE
Testruns are failing on OS X if real binary or new signed app bundle get specified (#183)

### DIFF
--- a/mozmill_automation/application.py
+++ b/mozmill_automation/application.py
@@ -2,19 +2,13 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import ConfigParser
 import os
 import re
 import sys
 
+import mozinfo
+
 import errors
-
-
-def get_bin_folder(app_folder):
-    """ Returns the folder which contains the binaries of the application. """
-    if sys.platform in ("darwin"):
-        app_folder = os.path.join(app_folder, 'Contents', 'MacOS')
-    return app_folder
 
 
 def get_mozmill_tests_branch(gecko_branch):
@@ -32,15 +26,17 @@ def get_mozmill_tests_branch(gecko_branch):
     return branch
 
 
-def is_app_folder(path):
-    """ Checks if the folder is an application folder. """
-    if sys.platform != "darwin":
+def is_application(path, application):
+    """Check if the path is a supported application"""
+    if path.endswith('.app'):
+        path = os.path.join(path, 'Contents', 'MacOS')
+    else:
         path = os.path.dirname(path)
 
-    file = os.path.join(get_bin_folder(path),
-                        "application.ini")
+    if mozinfo.isWin:
+        application += '.exe'
 
-    return os.path.exists(file)
+    return os.path.exists(os.path.join(path, application))
 
 
 def is_installer(path, application):

--- a/mozmill_automation/testrun.py
+++ b/mozmill_automation/testrun.py
@@ -103,10 +103,10 @@ class TestRun(object):
             raise errors.NotFoundException('Path cannot be found', build)
 
         # Check if it's an installer or an already installed build
-        # We have to custom checks via application.is_app_folder as long as
+        # We have to custom checks via application.is_application as long as
         # mozinstall can't check for an installer (bug 795288)
         if application.is_installer(build, self.options.application) or \
-                application.is_app_folder(build):
+                application.is_application(build, self.options.application):
             self._binary = build
             return
 

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ VERSION = '2.1-dev'
 
 deps = ['mercurial == 2.6.2',
         'mozdownload >= 1.11.1',
+        'mozinfo >= 0.7',
         'mozfile >= 1.0',
         'mozinstall >= 1.7',
         'mozmill == 2.1-dev',


### PR DESCRIPTION
This will fix issue #183, and allows us to run a real binary and the new signed builds on OS X. @andreeamatei please review ASAP. Also can you please test this patch on Linux and Windows? I would kinda appreciate that.
