### PR TITLE
Adjust handling of --target-buildid for usage with Mozmill CI (#186)

### DIFF
--- a/mozmill_automation/testrun.py
+++ b/mozmill_automation/testrun.py
@@ -633,6 +633,8 @@ class UpdateTestRun(TestRun):
             self.options.allowed_mar_channels = None
         if self.options.override_update_url == 'None':
             self.options.override_update_url = None
+        if self.options.target_buildid == 'None':
+            self.options.target_buildid = None
 
         self.results = [ ]
 


### PR DESCRIPTION
This fixes issue #186. Please keep in mind that I created this PR for hotfix-2.0 given that Mozmill 2.1-dev doesn't work right now. I will make sure to land it first on default, and cherry-pick for hotfix-2.0. @andreeamatei or @andreieftimie can one of you have a look at it please?
