### PR TITLE
If no application repository information is available, assume mozilla-release

### DIFF
--- a/mozmill_automation/application.py
+++ b/mozmill_automation/application.py
@@ -4,24 +4,27 @@
 
 import os
 import re
-import sys
 
 import mozinfo
-
-import errors
 
 
 def get_mozmill_tests_branch(gecko_branch):
     """ Identify the mozmill-tests branch from the application branch. """
 
+    # If no branch information is available assume we have a release build.
+    # All binaries on Ubuntu and maybe other distributions don't have it set.
+    if not gecko_branch:
+        return 'mozilla-release'
+
     # Retrieve the name of the repository
     branch = re.search('.*/([\S\.]+$)', gecko_branch).group(1)
 
-    # Supported branches: mozilla-aurora, mozilla-beta, mozilla-release, mozilla-esr*
-    # All other branches (mozilla-central, mozilla-inbound, birch, elm, oak etc.) should fallback to the 'default' branch
-    # This will work with Firefox and Thunderbird
+    # Supported branches: mozilla-aurora, mozilla-beta, mozilla-release,
+    #                     mozilla-esr*
+    # All other branches (mozilla-central, mozilla-inbound, ux etc.)
+    # should fallback to the 'default' branch
     if not re.match(r'.*/releases/', gecko_branch):
-        branch = "default"
+        branch = 'default'
 
     return branch
 


### PR DESCRIPTION
This fix will let us run our Mozmill tests on Linux machines with customized Firefox instances. On e.g. Ubuntu there is no application repository information available, so right now we fail in running the tests.

This is a great enhancement we should also get out soon. So can someone please review? Thanks.
