### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ deps = ['mercurial == 2.6.2',
         'mozinfo >= 0.7',
         'mozfile >= 1.0',
         'mozinstall >= 1.7',
-        'mozmill == 2.1-dev',
+        'mozmill == 2.0.9',
         'mozversion >= 0.7'
         ]
 


### PR DESCRIPTION
Setup throws the error: "No local packages or download links found for mozmill==2.1-dev"

Couldn't find 2.1-dev version anywhere online. Should we be using 2.0.9 which is available? Using 2.0.9 throws another error though, which I haven't been able to resolve:

Processing dependencies for mozmill-automation==2.1-dev
Traceback (most recent call last):
  File "setup.py", line 57, in <module>
    """,
  File "C:\Program Files (x86)\Python27\Lib\distutils\core.py", line 151, in set
up
    dist.run_commands()
  File "C:\Program Files (x86)\Python27\Lib\distutils\dist.py", line 953, in run
_commands
    self.run_command(cmd)
  File "C:\Program Files (x86)\Python27\Lib\distutils\dist.py", line 972, in run
_command
    cmd_obj.run()
  File "build\bdist.win32\egg\setuptools\command\develop.py", line 32, in run
  File "build\bdist.win32\egg\setuptools\command\develop.py", line 132, in insta
ll_for_development
  File "build\bdist.win32\egg\setuptools\command\easy_install.py", line 704, in
process_distribution
TypeError: not enough arguments for format string
