### PR TITLE
mozversion 1.0 required by mozmill 2.1-dev

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ deps = ['mercurial == 2.6.2',
         'mozfile >= 1.0',
         'mozinstall >= 1.7',
         'mozmill == 2.1-dev',
-        'mozversion >= 0.7'
+        'mozversion == 1.0'
         ]
 
 setup(name=NAME,


### PR DESCRIPTION
Setup throws the error: **TypeError: not enough arguments for format string**

On debugging using _pdb_, I see the following:

```
prompt>python -m pdb setup.py develop
...
...
...
(Pdb) l
699                 )
700             except VersionConflict:
701                 e = sys.exc_info()[1]
702                 raise DistutilsError(
703                     "Installed distribution %s conflicts with requirement %s
"
704  ->                 % e.args
705                 )
706             if self.always_copy or self.always_copy_from:
707                 # Force all the relevant distros to be copied or activated
708                 for dist in distros:
709                     if dist.key not in self.installed_projects:
(Pdb) p e
VersionConflict("mozversion 1.1 is installed but mozversion==1.0 is required by
['mozmill']",)
(Pdb)
```

mozversion 1.1 is the one available on pypi
