### PR TITLE
Fix handling of binary for MozMill.create() (#201)

### DIFF
--- a/mozmill_automation/testrun.py
+++ b/mozmill_automation/testrun.py
@@ -291,12 +291,13 @@ class TestRun(object):
 
         profile_args = dict(profile=profile_path,
                             addons=self.addon_list,
-                            preferences=self.preferences)
-        runner_args = dict(binary=self._application)
+                            preferences=self.preferences,
+                            )
         mozmill_args = dict(app=self.options.application,
+                            binary=self._application,
                             handlers=handlers,
                             profile_args=profile_args,
-                            runner_args=runner_args)
+                            )
         if self.timeout:
             mozmill_args['jsbridge_timeout'] = self.timeout
         self._mozmill = mozmill.MozMill.create(**mozmill_args)


### PR DESCRIPTION
This fixes issue #201. @andreeamatei could you have a look at this PR please? Without it we cannot run anything on master at the moment. Thanks.